### PR TITLE
Daily brief 2026-02-12

### DIFF
--- a/briefs/daily/2026-02-12.md
+++ b/briefs/daily/2026-02-12.md
@@ -2,91 +2,117 @@
 Meta: timezone=Europe/Zurich; lookback=24h
 
 ## 1) Top 5 market-moving developments
-1. US data strength (jobs) reprices near-term Fed cuts; front-end yields jump and USD firms → Channels: Rates/FX → Why now: higher-for-longer narrative gets reinforced into the next inflation print → Watch (24–72h): US CPI; follow-through in 2Y/10Y and risk assets  [Rates][FX]
-2. Global risk tone stays constructive with Asian equities at/near record levels despite higher US yields → Channels: Equities/FX → Why now: growth/risk appetite offsets rate headwind for now → Watch (24–72h): whether US yields keep rising; US inflation data as a catalyst for cross-asset rotation  [Equities][FX]
-3. JPY continues to strengthen even as broad USD firms, keeping carry-unwind sensitivity elevated → Channels: FX/Volatility → Why now: positioning is crowded and catalysts (rates, politics, risk) can force fast deleveraging → Watch (24–72h): USD/JPY volatility; any BoJ signaling; broader risk-off confirmation  [FX][Volatility]
-4. Gold catches a bid into macro-event risk as investors hedge tail outcomes (rates/inflation/geopolitics) → Channels: Volatility/FX → Why now: hedging demand rises when macro uncertainty is front-loaded into the calendar → Watch (24–72h): real-yield direction post-CPI; USD follow-through  [Volatility][FX]
-5. Oil risk premium nudges higher on renewed US–Iran tensions narrative, keeping energy → inflation pass-through on the radar → Channels: Energy/Inflation → Why now: geopolitical headline risk can reprice crude quickly even without physical disruption → Watch (24–72h): official statements/sanctions chatter; any shipping/security incidents  [Energy][Inflation]
+1. US January jobs beat (NFP +130k, unemployment 4.3%) keeps Fed cuts pushed back and nudges front-end and 10Y Treasury yields higher → Channels: Rates/FX/Credit/Equities → Why now: markets had leaned toward earlier cuts after softer data; a clean payrolls beat plus downward revisions to 2025 still leave labor resilient, so futures trim 2026 easing expectations and 2Y ≈3.5% and 10Y ≈4.2% → Watch (24–72h): follow-through from claims and CPI, Fed speakers’ tolerance for slower disinflation, and whether renewed dollar strength tightens global financial conditions, especially for EM.  [Rates][FX][Credit][Equities][Growth]
+2. Oil up ~2% as US–Iran tensions and a new MARAD Strait of Hormuz security advisory add risk premium to Middle East barrels → Channels: Energy/Shipping/Sanctions → Why now: Brent near 70 USD and WTI mid‑60s reflect both stronger demand signals and concern that potential interception of Iranian crude plus harassment incidents in Hormuz could disrupt flows or lift insurance and freight costs → Watch (24–72h): any confirmed kinetic incident or boarding attempt, tanker rerouting patterns, and OPEC+ guidance on balancing prices versus volumes.  [Energy][Shipping][Sanctions][Inflation]
+3. US maritime advisory 2026-001 formally warns U.S.-flagged ships to stay “as far as possible” from Iranian waters in Hormuz → Channels: Shipping/Energy/Volatility → Why now: the advisory cites a Feb 3 harassment attempt and removes prior language downplaying threats to U.S.-flagged vessels, raising the floor on perceived maritime risk even though traffic still flows; insurers and owners reassess premiums and routing while monitoring for copycat guidance by other flags → Watch (24–72h): follow-up notices from UKMTO and major liners, any increase in war-risk premia or AIS “dark” traffic, and evidence that non-U.S. operators shadow the U.S. risk posture.  [Shipping][Energy][Volatility]
+4. Chinese yuan grinds toward a three-year high as PBoC pairs strong fixings with heavy pre–Lunar New Year liquidity support → Channels: FX/Liquidity/Growth → Why now: USD/CNY around 6.90 with an 11‑week rally and firm daily fixings signals Beijing’s comfort with a somewhat stronger currency even as it injects large repo liquidity to bridge a multi-trillion-yuan holiday funding gap → Watch (24–72h): whether CNY strength caps broader dollar gains after the US jobs surprise, offshore CNH basis moves, and any sign that a firmer CNY tightens conditions for exporters or pressures weaker EM FX baskets.  [FX][Liquidity][Growth]
+5. Japan’s Nikkei breaks above 58,000 on tech-led inflows despite BoJ signaling patience, as markets eye the risk of earlier rate hikes → Channels: Equities/Rates/FX/Volatility → Why now: robust earnings and global risk-on keep Japanese equities bid while JGB 10Y yields around 2.2% and talk of up to three BoJ hikes in 2026 underline that the last ultra‑easy central bank is normalizing, anchoring JPY carry and global duration risk → Watch (24–72h): JGB auction results, yen reaction to further BoJ commentary, and any rotation between global tech and Japan exposure.  [Equities][Rates][FX][Volatility]
 
 ## 2) Confirmed vs Reported
 ### Confirmed (primary-source)
-- US CPI release schedule (BLS) — timing risk for rates/FX positioning into Friday’s print [Inflation][Rates] ([BLS CPI release schedule](https://www.bls.gov/schedule/news_release/cpi.htm))
-- US Treasury daily rate data availability (Treasury.gov) — reference point for verifying curve moves [Rates] ([Daily Treasury Yield Curve Rates](https://home.treasury.gov/resource-center/data-chart-center/interest-rates))
+- US January Employment Situation (BLS) — Nonfarm payrolls rose by 130,000 in January while the unemployment rate edged down to 4.3%, keeping the labor market tighter than markets had priced and reducing room for aggressive Fed cuts. [Rates][FX][Growth]
+- US Maritime Advisory 2026-001 on Hormuz (MARAD) — Six‑month guidance instructing U.S.-flagged vessels to stay as far as practicable from Iranian waters and to decline boarding requests where safely possible, formalizing a higher baseline risk assessment at a critical oil chokepoint. [Shipping][Energy][Sanctions]
+- ECB wage tracker update — New wage tracker data point to negotiated wage growth around 3.0% in 2025 and 2.7% in 2026, reinforcing the narrative that euro-area wage pressures are normalizing toward levels compatible with the 2% inflation target. [Rates][Inflation][Growth]
+- PBoC pre-holiday liquidity operations — Large 14‑day repo and reverse-repo injections plus prior medium-term funding signal a “moderately loose” stance aimed at smoothing a sizeable Lunar New Year liquidity gap while supporting domestic demand. [Liquidity][FX][Growth]
 
 ### Reported (secondary)
-- Stronger-than-expected US labor data lifted the dollar and pushed Treasury yields higher; Asian equities climbed to a record high (Reuters) — implies more resistance for duration if data momentum persists [Rates][FX][Equities] ([Reuters global markets wrap](https://www.reuters.com/world/china/global-markets-wrapup-1-2026-02-12/))
-- US Treasury yields rose after a strong January jobs report (CNBC) — underscores front-end sensitivity to labor/inflation surprises [Rates] ([CNBC: U.S. Treasury yields](https://www.cnbc.com/2026/02/11/us-treasury-yields-investors-await-delayed-january-jobs-report.html))
-- Euro area yields modestly fell while peripheral spreads stayed contained; USD strengthened vs most peers while JPY outperformed (CaixaBank Research) — suggests no immediate fragmentation shock, but FX dispersion remains key (CaixaBank) [Rates][FX] ([CaixaBank daily report](https://www.caixabankresearch.com/en/publications/financial-markets-daily-report/12-february-2026))
+- BoJ could hike rates up to three times in 2026 (sell-side and bank strategist commentary) — would imply a faster normalization path than current consensus and help narrow yield differentials, but remains a scenario rather than BoJ guidance. [Rates][FX][Equities]
+- European Commission proposal for a broader sanctions package targeting maritime services for Russian crude — if adopted, would materially raise constraints on shadow-fleet tankers and EU-linked services, but still faces negotiation and potential dilution among member states. [Energy][Sanctions][Shipping]
+- Analyst views that US–Iran tensions could escalate from advisory posture to active interception of tankers — highlight upside tail risk to Hormuz but lack concrete evidence of imminent kinetic action beyond recent harassment and updated guidance. [Energy][Shipping][Defense]
 
 ## 3) Rates & FX scoreboard
-- USD rates / Fed: Front-end led the selloff after the jobs surprise; March cut pricing faded sharply, while markets still look for multiple cuts later in 2026. Next catalyst is US CPI on Friday.
-- EUR rates / ECB: Euro area yields drifted modestly lower with peripheral spreads broadly stable; ECB narrative remains dominated by global rates impulse rather than new local shocks.
-- JPY / BoJ: JPY strength persists against a firmer USD backdrop, keeping an eye on carry/vol feedback loops and any BoJ communication risk.
-- GBP / BoE: GBP largely trades as USD-beta with rates; no major BoE-specific catalyst flagged in the last 24h.
-- CNY/CNH / PBoC + China: China CPI data points to softer price momentum than expected, keeping focus on growth-supportive policy bias and FX-fixing narrative.
+- USD rates / Fed: Stronger January payrolls data (130k vs ~70k expected) and a dip in unemployment to 4.3% saw the U.S. 10Y Treasury yield grind back up toward the mid‑4.1–4.2% area and the 2Y move closer to the mid‑3.5% range, reversing some of the prior dovish repricing. Futures now price a slightly later and shallower 2026 easing path, with markets waiting on the next CPI print and upcoming Fed speakers to see whether the Committee leans into a “higher for longer neutral” narrative or treats the report as noise. Dollar indices are modestly firmer, with high-beta FX underperforming while core G10 remains relatively stable.
+- EUR rates / ECB: The ECB kept its main refinancing rate at 2.15% at the early‑February meeting and fresh wage-tracker data show negotiated wages drifting toward sub‑3% by end‑2026, broadly consistent with the Bank’s “good place” framing on inflation. Euro-area curves are relatively calm: mild bull‑flattening after the meeting has partially unwound as global yields lift post‑NFP, but there is no clear fragmentation stress in periphery spreads. The next catalysts are hard data on growth and services inflation rather than policy surprises.
+- JPY / BoJ: The BoJ held its policy rate at 0.75% in January with an 8–1 vote, but JGB yields remain elevated near 2.2% on expectations of further gradual hikes as inflation and wage growth stay above target. Media and street commentary now openly discuss the possibility of up to three rate increases in 2026, which would further erode rate differentials even if the path is shallow. For now, the yen remains soft versus the dollar given higher U.S. yields, but any hint of an earlier BoJ move could quickly trigger carry-unwind pressure.
+- GBP / BoE: GBP/USD is trading in the high‑1.36–low‑1.37 range after a recent grind higher, supported by relatively stable domestic politics and expectations that the BoE will stay cautious on cutting while core inflation remains sticky. The pound has outperformed some G10 peers over the past month but is sensitive to U.S. data: stronger U.S. labor prints and higher yields cap further upside, while any renewed UK growth wobble would quickly translate into renewed sterling vulnerability.
+- CNY/CNH / PBoC + China: The yuan continues to appreciate, with USD/CNY around 6.90 and offshore CNH testing multi‑year highs as the PBoC maintains stronger‑than‑model fixings and injects sizable pre‑holiday liquidity. Authorities are signalling comfort with a somewhat stronger currency alongside a “moderately loose” policy stance to stabilize activity and prices. For global markets, a firmer CNY offers some offset to broad USD strength and supports EM Asia FX, but also raises questions about export competitiveness if the trend persists.
 
 ## 4) Energy & shipping
-- Oil/gas narrative: Oil risk premium remains headline-sensitive (US–Iran tension narrative) while broader balance expectations still anchor price action.
-- Chokepoints (Hormuz, Red Sea/Suez, Taiwan Strait): No confirmed new kinetic incident in the last 24h in this brief; watch for advisories, rerouting, and insurance cost changes.
-- Inflation implication: A sustained crude bid into CPI risk can keep near-term inflation fears sticky even if core disinflation continues.
+- Oil/gas narrative: Brent is trading near 70 USD and WTI in the mid‑60s after a roughly 2% daily gain, driven by both improved demand signals and a geopolitical risk premium tied to US–Iran tensions and maritime security advisories. Inventories data and a solid macro backdrop have underpinned the recent uptrend, with futures curves reflecting a modest backwardation consistent with tighter balances. European gas prices remain subdued relative to the 2022–23 crisis period, with storage comfortable, but remain sensitive to any renewed shipping or pipeline disruption.
+- Chokepoints (Hormuz, Red Sea/Suez, Taiwan Strait): Hormuz is in focus after MARAD’s 2026‑001 advisory urged U.S.-flagged vessels to stay as far as practicable from Iranian waters and outlined protocols if challenged, citing harassment as recent as Feb 3; traffic continues but with a higher perceived baseline risk. Red Sea/Suez remains structurally fragile as the UN Security Council has extended Red Sea attack reporting, but recent days have been relatively quiet with many major liners still routing via the Cape. The Taiwan Strait is calm in the last 24h, with no new incidents beyond routine PLA activity already priced by regional markets.
+- Inflation implication: A sustained move in Brent above ~70 USD, if reinforced by any additional chokepoint stress, would re‑introduce an upside skew to energy-sensitive CPI components and freight-sensitive core goods. For now, the combination of contained gas prices and only moderate oil gains argues for a manageable inflation impulse, but any escalation around Hormuz could quickly feed into headline inflation expectations and complicate central-bank easing plans.
 
 ## 5) Sanctions / export controls / policy actions
-- No major new binding sanctions/export-control actions with clear immediate market channel were confirmed in the last 24h (watch US/EU policy lines tied to Iran/Russia/China) [Sanctions][ExportControls]
+- Recent U.S. sanctions have expanded pressure on Iranian petroleum shipping networks, designating additional entities and vessels tied to shadow-fleet movements of Iranian oil; while these measures predate the last 24 hours, they frame the backdrop for the current Hormuz risk premium by signalling a tougher enforcement stance on maritime intermediaries. → Market channel: higher compliance costs and risk premia for tankers interacting with Iranian-linked barrels, potentially tightening effective supply even without formal embargoes. [Energy][Sanctions][Shipping]
+- The U.S. Maritime Administration’s 2026‑001 advisory itself is a de facto policy action: it supersedes prior guidance and explicitly recommends that U.S.-flagged vessels remain as far as possible from Iran’s territorial sea and hug Omani waters when eastbound through Hormuz, with AIS left on. → Market channel: reinforces the perception that operating near Iranian waters carries elevated legal and security risk, supporting higher war-risk insurance and encouraging route adjustments that can marginally raise transport costs. [Shipping][Energy][Defense]
+- On the technology front, recent U.S. export-control rule updates shift some high‑end AI and semiconductor exports to China from a presumption of denial to case‑by‑case review under stricter compliance conditions, alongside separate policy moves (tariffs and Section 232 actions) that incentivize onshoring of semiconductor production. → Market channel: maintains strategic pressure on China’s advanced compute and foundry ecosystem while creating ongoing headline risk for semiconductor supply chains and related equities. [ExportControls][Equities][SupplyChains]
 
 ## 6) Watchlist tiles (Tier 1 then Tier 2)
-### United States
+### United States (US)
 Signals (3):
-- Labor data surprise shifted near-term Fed-cut pricing.
-- 2Y yields led the move higher; USD recovered vs most G10.
-- Risk assets stayed resilient (Asia record high), suggesting strong risk appetite.
+- January payrolls beat (130k vs ~70k expected) with unemployment at 4.3%, confirming a still‑resilient labor market despite large downward revisions to 2025 job gains.
+- U.S. Treasury yields drift higher post‑report, with 2Y and 10Y moving several basis points up as markets trim the number and timing of 2026 Fed cuts.
+- Dollar indices stabilize and edge higher after a soft patch, weighing on high‑beta and EM FX while leaving core G10 largely range‑bound.
 Key uncertainty (1):
-- Whether CPI validates “higher for longer” or reopens earlier easing.
+- Whether the combination of solid labor data and only gradual disinflation pushes the Fed toward signalling “fewer, later” cuts, or whether policymakers look through one month of data to keep the door open to easing in H2.
 Triggers (24–72h) (3):
-- US CPI print: upside surprise risk.
-- Follow-through in 2Y/10Y yields and curve shape.
-- USD vs JPY: disorderly carry unwind signal.
+- Next major U.S. inflation print (CPI/PCE) that could validate or challenge the notion of sticky services inflation.
+- Fed speakers’ guidance on how much weight they place on the January jobs print relative to prior soft data and the government shutdown noise.
+- Signs of tightening in U.S. credit conditions or funding markets (spreads, repo, bill yields) that might offset the hawkish read-through from stronger jobs.
 
-### Euro area (ECB)
+### Euro area (EA)
 Signals (3):
-- Euro area yields modestly lower; spreads contained.
-- EUR traded as a function of USD/rates rather than local shock.
-- Risk tone supportive; no fragmentation escalation flagged.
+- ECB keeps policy rates on hold and reiterates that inflation is broadly on track to return to target, with recent wage data reinforcing the normalization story.
+- Euro-area sovereign spreads remain contained, with no sign of acute fragmentation despite higher global yields post‑NFP.
+- EUR trades slightly softer versus a firmer USD but without disorderly moves, suggesting FX markets see limited policy divergence for now.
 Key uncertainty (1):
-- Transmission of higher US yields into European financial conditions.
+- How quickly core services inflation converges toward 2% and whether any renewed energy or shipping shock reopens the debate about the appropriate real policy rate.
 Triggers (24–72h) (3):
-- US CPI spillover into EUR rates/FX.
-- Any ECB speaker hinting at reaction function changes.
-- Peripheral spread widening tied to fiscal/policy headlines.
+- Upcoming euro-area inflation releases and revisions to ECB staff projections or wage tracker details.
+- Any surprise in peripheral issuance or auction metrics that might hint at latent fragmentation risk.
+- New EU discussions on tightening enforcement of Russia-related energy and shipping sanctions.
 
-### Saudi Arabia (Tier 2)
+### China (CN)
 Signals (3):
-- Oil pricing remains sensitive to geopolitical headlines.
-- OPEC+ guidance remains a background anchor for balances.
-- Demand narrative hinges on global growth and USD.
+- CNY and CNH continue to appreciate, with USD/CNY around 6.90 and offshore yuan near a multi‑year high, supported by strong fixings and reserve accumulation.
+- PBoC steps up liquidity injections via 14‑day repos and other tools ahead of Lunar New Year, aiming to cover an estimated multi‑trillion‑yuan funding gap and avoid money-market stress.
+- Chinese risk assets take the stronger currency in stride, benefiting from global risk-on and hopes that policy remains supportive of growth.
 Key uncertainty (1):
-- Whether geopolitics translates into physical disruption vs headline-only risk premium.
+- Whether authorities will tolerate continued CNY strength if global conditions tighten (via higher U.S. yields or renewed trade frictions), or revert to a weaker fixing bias to cushion exports.
 Triggers (24–72h) (3):
-- Any official producer guidance shift.
-- Hormuz/Red Sea incident escalation.
-- US policy/sanctions actions that affect flows.
+- Additional PBoC operations and any communication hinting at the desired FX level or volatility.
+- Lunar New Year travel and spending data as a read on domestic demand momentum.
+- Any new U.S. or allied export‑control or tariff headlines that could shift the medium‑term growth and FX narrative.
 
 ## 7) Mindmap updates
 Add nodes (≤3):
-- US labor resilience (Feb)
-- Fed-cut repricing risk into CPI
-- JPY carry-unwind sensitivity
+- MARAD 2026‑001 Hormuz advisory (formal U.S. guidance elevating baseline chokepoint risk).
+- US Jan 2026 labor re‑acceleration (jobs beat with structurally weaker prior year).
+- CNY multi‑year high vs USD (stronger yuan alongside loose domestic liquidity).
 
 Add edges (≤5):
-- US jobs surprise → UST front-end yields up (label: repricing)
-- UST front-end yields up → USD firmer (label: rate differential)
-- USD firmer + JPY strength → FX vol risk (label: positioning)
-- Geopolitics (US–Iran) → oil risk premium (label: headline risk)
-- US CPI surprise → cross-asset rotation (label: catalyst)
+- US Jan 2026 labor re‑acceleration → Fed cuts timing (label: "pushes cuts later unless inflation undershoots").
+- MARAD 2026‑001 Hormuz advisory → Strait of Hormuz chokepoint (label: "heightened boarding/harassment risk").
+- MARAD 2026‑001 Hormuz advisory → Oil risk premium (label: "war‑risk and insurance channel").
+- CNY multi‑year high → EM FX conditions (label: "China-led support for Asia FX").
+- BoJ gradual hikes narrative → Global duration risk (label: "end of last ultra‑easy anchor").
 
 ## 8) Linear issue drafts (max 3)
-### Issue draft
+### Issue draft 1
 Title:
+Clarify chokepoint trigger behavior for advisory-only vs kinetic events
 Labels:
+[Shipping][Energy][Sanctions][LinearOps][TriggerTuning]
 Problem:
+Current triggers.yml and INDICATORS.md treat "chokepoint disruption" as a single bucket, but recent MARAD guidance shows a grey zone where risk premia rise on advisories and harassment without confirmed kinetic attacks or sustained rerouting. Tasks risk over‑promoting advisory-only moves into Top‑5, or under‑weighting them when oil moves are modest but legal/insurance risk is rising.
 Evidence:
+- MARAD Maritime Security Advisory 2026‑001 (Strait of Hormuz and Gulf of Oman) formalizing guidance to U.S.-flagged ships.
+- Recent ~2% move in Brent and reports of higher perceived boarding risk, without clear evidence of large-scale rerouting yet.
 Proposed fix (file + exact change):
+- In triggers.yml under energy_shipping.chokepoint_disruption, add a sub-note distinguishing (a) advisory/harassment phase and (b) kinetic/rerouting phase, with separate expectations for Top‑5 promotion. For example: "Advisory/harassment-only: treat as watchpoint unless combined with ≥X% daily move in Brent or clear evidence of rerouting; Kinetic/rerouting: default Top‑5 with explicit freight and inflation mapping." Also cross-reference INDICATORS.md section 6 to clarify example thresholds.
+Success criteria:
+- Over the next 3–5 advisory events without major kinetic incidents, daily briefs capture maritime risk as watchpoints with clear mechanism text but avoid crowding out Tier‑1 macro items in Top‑5 unless price and flow thresholds are met.
+
+### Issue draft 2
+Title:
+Tighten guidance on FX thresholds for Top‑5 promotion
+Labels:
+[FX][Liquidity][Growth][LinearOps][TriggerTuning]
+Problem:
+INDICATORS.md highlights broad USD tone and EM stress but does not specify when a strong, policy‑driven FX move (e.g., sustained CNY appreciation with heavy liquidity operations) should be promoted into Top‑5 versus left as a watchpoint. This can lead to inconsistent treatment of FX stories that matter mainly via second‑round effects on global liquidity and trade.
+Evidence:
+- Recent multi‑week CNY appreciation toward a three‑year high alongside significant PBoC liquidity injections and stronger fixings, with limited immediate stress but important medium‑term implications for EM and tradeflows.
+Proposed fix (file + exact change):
+- In INDICATORS.md section 2 (FX), add explicit heuristics, for example: "Promote to Top‑5 when (a) broad USD index moves ≥X% in 1–3 sessions with clear macro catalyst, or (b) a systemically important FX pair (e.g., USD/JPY, USD/CNY) moves beyond defined ranges with an explicit policy shift or liquidity action and plausible spillovers to EM funding or trade." Include examples for CNY strength episodes and JPY carry-unwind risk.
+Success criteria:
+- Over the next quarter, FX items in Top‑5 are traceably linked to these thresholds, while smaller or slower FX moves are consistently captured as watchpoints with clear mechanism notes but without diluting Top‑5.


### PR DESCRIPTION
Daily brief for 2026-02-12 covering: (1) US January jobs beat and Fed repricing; (2) Oil move and Hormuz risk premium after MARAD advisory 2026-001; (3) Shipping/security posture in the Strait of Hormuz; (4) CNY strength and PBoC liquidity operations; (5) Nikkei record highs amid BoJ normalization. Includes Confirmed vs Reported split, Rates/FX and Energy/shipping scoreboards, sanctions/export-controls summary, Tier-1 watchlist tiles, mindmap updates, and Linear issue drafts on chokepoint triggers and FX thresholds.