### PR TITLE
CB drivers 2026-02-12

### DIFF
--- a/briefs/drivers/2026-02-12_cb_drivers.md
+++ b/briefs/drivers/2026-02-12_cb_drivers.md
@@ -1,0 +1,112 @@
+# Central Banks & Macro Driver Update — 2026-02-12 (CET)
+
+Scope: Official communications in the last 24h for Fed, ECB, BoJ, BoE, PBoC, plus next scheduled events. Flagged via INDICATORS.md as "Potential repricing catalyst" vs "Noise / confirms prior" for core rates/FX channels.
+
+## Federal Reserve (Fed)
+
+**Latest official communication (last 24h window)**
+- No new FOMC statement, speech text, or policy report dated 11–12 February 2026 on federalreserve.gov. The most recent entries are:
+  - Calendar listing of February speeches and releases (including Jefferson, Cook, Bowman, Miran events) without newly posted 11–12 February speech texts yet. (Calendar: https://www.federalreserve.gov/newsevents/2026-february.htm)
+  - Recent postings page updated through 11 February 2026, but pointing back to earlier materials (stress-test scenarios, prior speeches, and statistical releases). (Recent postings: https://www.federalreserve.gov/recentpostings.htm)
+
+**Assessment vs INDICATORS.md**
+- Category: Rates / policy path.
+- Status: **Noise / confirms prior.**
+  - Reasoning: No fresh policy guidance or surprise operations in the last 24h; markets are still digesting the January FOMC statement and earlier January speeches. Per INDICATORS.md, attention for US rates focuses on large yield moves or clear guidance pivots; neither is being driven by new Fed communication today.
+
+**Next scheduled Fed events (policy-relevant)**
+- Speech — Vice Chair Philip N. Jefferson, *Economic Outlook and Supply-Side Inflation Dynamics* at Brookings (February 9, 2026, Washington, D.C.), calendar-listed as a February speech event.  
+  Primary link: https://www.federalreserve.gov/newsevents/2026-february.htm  
+- Release — FOMC Minutes for the January 27–28 meeting (February 18, 2026, 2:00 p.m. ET).  
+  Primary link: https://www.federalreserve.gov/newsevents/2026-february.htm
+
+
+## European Central Bank (ECB)
+
+**Latest official communication (last 24h window)**
+- Speech — *Made in Europe* by Isabel Schnabel, ECB Executive Board member, delivered in Vienna on 11 February 2026.  
+  Primary link: https://www.ecb.europa.eu/press/key/date/2026/html/ecb.sp260211~2822ae9612.en.html
+  - Focus: Europe’s structural competitiveness, Single Market scale, and a proposed “28th regime” to help firms scale across the EU.
+  - Monetary-policy read-through: Emphasises structural growth and productivity rather than near-term rate moves; does not signal a change to the current ECB stance that inflation is moving toward target with rates on hold.
+
+**Assessment vs INDICATORS.md**
+- Category: Rates / growth / regulation.
+- Status: **Noise / confirms prior.**
+  - Reasoning: The speech is largely structural and medium-term, reinforcing prior ECB narratives on productivity, fiscal reform, and the Single Market. It does not alter near-term expectations for the policy path or yields and therefore does not by itself constitute a 1–3 session repricing catalyst for euro-area rates.
+
+**Next scheduled ECB events (policy-relevant)**
+- Ongoing: February 2026 monetary policy decision and press conference already concluded earlier in the month; no separate 11–12 February policy statement.
+- Forward-looking: No specific dated rate-setting event within the next week beyond standard data releases and speeches; next major catalyst remains the upcoming ECB monetary policy meeting (date on ECB calendar, not reiterated here to avoid stale details).  
+  Primary ECB calendar: https://www.ecb.europa.eu/press/calendar/html/index.en.html
+
+
+## Bank of Japan (BoJ)
+
+**Latest official communication (last 24h window)**
+- No new BoJ speech or statement dated 11–12 February 2026.
+- Most recent major communication:  
+  - Speech — *Economic Activity, Prices, and Monetary Policy in Japan* by Policy Board member MASU Kazuyuki, delivered 6 February 2026 in Ehime, outlining the view that if the January 2026 Outlook scenario is realised, the BoJ will continue to raise the policy interest rate in line with improvement in economic activity and prices.  
+    Primary link (PDF): https://www.boj.or.jp/en/about/press/koen_2026/data/ko260206a1.pdf
+
+**Assessment vs INDICATORS.md**
+- Category: Rates / JGBs / FX.
+- Status for last 24h: **Noise / confirms prior.**
+  - Reasoning: There is no fresh BoJ communication in the 11–12 February window; the Masu speech from 6 February has already been absorbed and was consistent with the existing narrative of gradual normalization. INDICATORS.md flags BoJ attention around explicit ops or guidance shifts; incremental board-member hawkishness is important context but not a new catalyst today.
+
+**Next scheduled BoJ events (policy-relevant)**
+- Speech — Board Member TAMURA Naoki at a meeting held by the Kanagawa Keizai Doyukai on 13 February 2026 (listed in BoJ release schedule).  
+  Primary link: https://www.boj.or.jp/en/about/calendar/index.htm
+- Upcoming Monetary Policy Meeting — next MPM dates listed on BoJ schedule (March 18–19, 2026).  
+  Primary link: https://www.boj.or.jp/en/about/calendar/index.htm
+
+
+## Bank of England (BoE)
+
+**Latest official communication (last 24h window)**
+- No new Monetary Policy Summary or fresh policy speech text dated 11–12 February 2026 on bankofengland.co.uk.
+- Relevant recent / forward-looking items:
+  - Monetary Policy Summary and Minutes — February 2026 meeting (decision on 4 February 2026 to maintain Bank Rate at 3.75% with a close 5–4 split, signalling likely further cuts in time).  
+    Primary link: https://www.bankofengland.co.uk/monetary-policy-report/2026/february-2026
+  - Upcoming events page indicates:
+    - James Talbot climate-related speech text scheduled for release on 11 February at 11:00 (UK time), primarily about climate risk and the BoE’s approach rather than the immediate rate path.  
+      Primary link: https://www.bankofengland.co.uk/events/upcoming-events
+
+**Assessment vs INDICATORS.md**
+- Category: Rates / FX / credit.
+- Status for last 24h: **Noise / confirms prior.**
+  - Reasoning: Within the 11–12 February window, there is no new BoE policy communication materially shifting the rate outlook beyond the early-February MPS and Report. The upcoming Talbot text is focused on climate and prudential topics, not near-term Bank Rate decisions, so it is not a direct 1–3 session repricing catalyst for gilts or GBP.
+
+**Next scheduled BoE events (policy-relevant)**
+- Text release — James Talbot speech *Measure, Model, Tackle, Tailor: The Bank of England’s approach to assessing and managing climate impacts across its core objectives* (text to be released 11 February 2026, 11:00 UK time).  
+  Primary link: https://www.bankofengland.co.uk/events/upcoming-events
+- Event — Huw Pill fireside chat at a Santander macroeconomic event on 13 February 2026, with slides to be released (macro context but typically incremental).  
+  Primary link: https://www.bankofengland.co.uk/events/upcoming-events
+
+
+## People’s Bank of China (PBoC)
+
+**Latest official communication (last 24h window)**
+- Q4 2025 Monetary Policy Implementation Report — summary carried by official state outlets on 11 February 2026, stating that the PBoC will continue to implement a "moderately loose" monetary policy in 2026 and will calibrate the strength, pace, and timing of tools as conditions evolve.  
+  Primary link (English summary, via State Council Information Office/Xinhua): http://english.scio.gov.cn/pressroom/2026-02/11/content_118328178.html
+  - Key points: commitment to supporting stable growth, guiding prices toward a reasonable recovery, strengthening support for domestic demand, technological innovation, and SMEs, and enhancing macroprudential and financial-stability toolkits.
+
+**Assessment vs INDICATORS.md**
+- Category: Liquidity / FX / growth.
+- Status: **Potential repricing catalyst (watch closely).**
+  - Reasoning: While the language is evolutionary rather than revolutionary, a formal quarterly policy report that reiterates a “moderately loose” stance and willingness to calibrate RRR and rate tools is relevant for China’s growth and liquidity impulse. In conjunction with recent strong fixings and liquidity injections, this communication helps anchor expectations for continued support and could influence CNY, onshore funding conditions, and EM Asia risk over the next few sessions.
+
+**Next scheduled PBoC events (policy-relevant)**
+- No specific dated FOMC-style meeting; communication is via reports, operations, and ad hoc announcements.
+- Next key reference documents will be subsequent monetary policy implementation reports and any official statements on RRR or policy-rate adjustments posted on the PBoC website and via Xinhua.  
+  Primary English portal: http://www.pbc.gov.cn/ (and State Council briefings via http://english.scio.gov.cn/)
+
+
+## Summary table — last 24h CB comms vs INDICATORS.md
+
+| Central bank | New official comms in last 24h (11–12 Feb 2026 CET) | Channel (INDICATORS.md) | Market impact flag |
+| --- | --- | --- | --- |
+| Fed | None (only calendar / recent postings updates) | Rates / USD | Noise / confirms prior |
+| ECB | Schnabel structural speech *Made in Europe* (11 Feb) | Growth / regulation (indirect to rates) | Noise / confirms prior |
+| BoJ | No new comms in window; latest is Masu speech from 6 Feb | Rates / JGBs / JPY | Noise / confirms prior (today) |
+| BoE | No new comms in window; Talbot text forthcoming, climate focus | Rates / FX / credit | Noise / confirms prior |
+| PBoC | Q4 2025 Monetary Policy Implementation Report (11 Feb, Xinhua/SCIO) | Liquidity / FX / growth | Potential repricing catalyst (watch CNY/liquidity)


### PR DESCRIPTION
Central bank driver update for 2026-02-12, covering official communications in the last 24h for Fed, ECB, BoJ, BoE, and PBoC, and classifying them via INDICATORS.md thresholds as potential repricing catalysts vs noise/confirmation. Includes next scheduled events per central bank with primary links, and highlights the PBoC Q4 2025 Monetary Policy Implementation Report as the only item with potential short-horizon repricing relevance (via China liquidity/FX).